### PR TITLE
Feature/inline var

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 #  Utils
 #  =====
 
@@ -20,7 +19,10 @@ endfunction()
 add_custom_target(tests COMMENT "Build all the unit tests.")
 add_dependencies(check tests)
 
+add_subdirectory(__inline_var_tests)
+
 file(GLOB_RECURSE zug_unit_tests "*.cpp")
+list(FILTER zug_unit_tests EXCLUDE REGEX "${CURRENT_CMAKE_DIRECTORY}/__*")
 
 foreach(_file IN LISTS zug_unit_tests)
   message("found unit test: " ${_file})

--- a/test/__inline_var_tests/CMakeLists.txt
+++ b/test/__inline_var_tests/CMakeLists.txt
@@ -1,0 +1,11 @@
+
+#  Targets
+#  =======
+
+message("adding unit test: inline_var_tests")
+
+file(GLOB_RECURSE inline_var_test_files "*.cpp")
+add_executable(inline_var_tests EXCLUDE_FROM_ALL ${inline_var_test_files})
+add_dependencies(tests inline_var_tests)
+target_link_libraries(inline_var_tests PUBLIC zug-dev)
+add_test("test/inline_var_tests" inline_var_tests)

--- a/test/__inline_var_tests/inline_var.cpp
+++ b/test/__inline_var_tests/inline_var.cpp
@@ -1,0 +1,27 @@
+//
+// zug: transducers for C++
+// Copyright (C) 2019 Juan Pedro Bolivar Puente (and Carl Bussey, maybe?)
+//
+// This software is distributed under the Boost Software License, Version 1.0.
+// See accompanying file LICENSE or copy at http://boost.org/LICENSE_1_0.txt
+//
+
+#include "resources/client1.hpp"
+#include "resources/client2.hpp"
+
+#include <zug/detail/inline_var.hpp>
+
+#include <catch2/catch.hpp>
+
+using namespace zug::detail;
+
+// static tests
+static_assert( 
+    std::is_same<decltype(make_inline_var<int>()), const int&>::value,
+    "Return type of make_inline_var is a const reference of template type"
+);
+
+TEST_CASE("inline_var: variable included in two files has same address")
+{
+    CHECK( client1::address_of_inline_var() == client2::address_of_inline_var() );
+}

--- a/test/__inline_var_tests/main.cpp
+++ b/test/__inline_var_tests/main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>

--- a/test/__inline_var_tests/resources/client1.cpp
+++ b/test/__inline_var_tests/resources/client1.cpp
@@ -1,0 +1,24 @@
+//
+// zug: transducers for C++
+// Copyright (C) 2019 Juan Pedro Bolivar Puente (and Carl Bussey, maybe?)
+//
+// This software is distributed under the Boost Software License, Version 1.0.
+// See accompanying file LICENSE or copy at http://boost.org/LICENSE_1_0.txt
+//
+
+#include "client1.hpp"
+
+#include <memory>
+
+namespace zug {
+namespace detail {
+namespace client1 {
+
+const to_be_inlined* address_of_inline_var()
+{
+    return std::addressof(inline_var);
+}
+
+} // namespace client1
+} // namespace detail
+} // namespace zug

--- a/test/__inline_var_tests/resources/client1.hpp
+++ b/test/__inline_var_tests/resources/client1.hpp
@@ -1,0 +1,21 @@
+//
+// zug: transducers for C++
+// Copyright (C) 2019 Juan Pedro Bolivar Puente (and Carl Bussey, maybe?)
+//
+// This software is distributed under the Boost Software License, Version 1.0.
+// See accompanying file LICENSE or copy at http://boost.org/LICENSE_1_0.txt
+//
+
+#pragma once
+
+#include "decl.hpp"
+
+namespace zug {
+namespace detail {
+namespace client1 {
+
+const to_be_inlined* address_of_inline_var();
+
+} // namespace client1
+} // namespace detail
+} // namespace zug

--- a/test/__inline_var_tests/resources/client2.cpp
+++ b/test/__inline_var_tests/resources/client2.cpp
@@ -1,0 +1,24 @@
+//
+// zug: transducers for C++
+// Copyright (C) 2019 Juan Pedro Bolivar Puente (and Carl Bussey, maybe?)
+//
+// This software is distributed under the Boost Software License, Version 1.0.
+// See accompanying file LICENSE or copy at http://boost.org/LICENSE_1_0.txt
+//
+
+#include "client2.hpp"
+
+#include <memory>
+
+namespace zug {
+namespace detail {
+namespace client2 {
+
+const to_be_inlined* address_of_inline_var()
+{
+    return std::addressof(inline_var);
+}
+
+} // namespace client2
+} // namespace detail
+} // namespace zug

--- a/test/__inline_var_tests/resources/client2.hpp
+++ b/test/__inline_var_tests/resources/client2.hpp
@@ -1,0 +1,21 @@
+//
+// zug: transducers for C++
+// Copyright (C) 2019 Juan Pedro Bolivar Puente (and Carl Bussey, maybe?)
+//
+// This software is distributed under the Boost Software License, Version 1.0.
+// See accompanying file LICENSE or copy at http://boost.org/LICENSE_1_0.txt
+//
+
+#pragma once
+
+#include "decl.hpp"
+
+namespace zug {
+namespace detail {
+namespace client2 {
+
+const to_be_inlined* address_of_inline_var();
+
+} // namespace client2
+} // namespace detail
+} // namespace zug

--- a/test/__inline_var_tests/resources/decl.hpp
+++ b/test/__inline_var_tests/resources/decl.hpp
@@ -1,0 +1,21 @@
+//
+// zug: transducers for C++
+// Copyright (C) 2019 Juan Pedro Bolivar Puente (and Carl Bussey, maybe?)
+//
+// This software is distributed under the Boost Software License, Version 1.0.
+// See accompanying file LICENSE or copy at http://boost.org/LICENSE_1_0.txt
+//
+
+#pragma once
+
+#include <zug/detail/inline_var.hpp>
+
+namespace zug {
+namespace detail {
+
+struct to_be_inlined {};
+
+static constexpr auto& inline_var = zug::detail::make_inline_var<to_be_inlined>();
+
+} // namespace detail
+} // namespace zug

--- a/zug/detail/inline_var.hpp
+++ b/zug/detail/inline_var.hpp
@@ -1,0 +1,30 @@
+//
+// zug: transducers for C++
+// Copyright (C) 2019 Juan Pedro Bolivar Puente (and Carl Bussey?)
+//
+// This software is distributed under the Boost Software License, Version 1.0.
+// See accompanying file LICENSE or copy at http://boost.org/LICENSE_1_0.txt
+//
+
+#pragma once
+
+namespace zug {
+namespace detail {
+
+template <typename T>
+struct inline_variable_holder
+{
+    static constexpr T value {};
+};
+
+template <typename T>
+constexpr T inline_variable_holder<T>::value;
+
+template <typename T>
+constexpr const T& make_inline_var()
+{
+    return inline_variable_holder<T>::value;
+}
+
+} // namespace detail
+} // namespace zug


### PR DESCRIPTION
To test this properly, we need multiple translation units within the test executable (so we can test that the variable has a unique address across all TUs). ~~To support this, I've had to refactor the test/CMakeLists.txt. To make sure it's still easy to add tests (and hard to not include tests), I've kept the glob approach to adding a test file, but as a result of that, it makes it difficult to have one test per executable (since we don't specify which file goes into which executable). Rather than over engineering something, I just packaged the tests into one executable. Since catch2 is any pretty heavy on the compile times, this would have some benefits, anyway. To run a specific test (without running all), you can use a commandline argument:~~

https://github.com/catchorg/Catch2/blob/master/docs/command-line.md#specifying-which-tests-to-run

~~Of course, you need to be able to match the test cases with a regular expression to do that, so we might need to rework the "reduce" test names (and any other on your branch) if we go for this.~~

Edit: the approach is now to split move the tests into a separate subdirectory. This is the cleanest way to exclude the inline_var tests from the glob. It makes the folder structure look a little bit awkward, but I'm personally in favour of that over the alternative. It's nice to keep the special cases completely separate, too, rather than slamming everything into the same CMakeLists.txt.