### PR TITLE
Optimize `copy_decay` trait

### DIFF
--- a/zug/transducer/chain.hpp
+++ b/zug/transducer/chain.hpp
@@ -15,8 +15,6 @@
 #include <zug/util.hpp>
 #include <zug/with_state.hpp>
 
-#include <zug/detail/copy_traits.hpp>
-
 namespace zug {
 
 struct chainr_tag

--- a/zug/transducer/dedupe.hpp
+++ b/zug/transducer/dedupe.hpp
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <zug/compose.hpp>
-#include <zug/detail/copy_traits.hpp>
 #include <zug/state_wrapper.hpp>
 #include <zug/util.hpp>
 #include <zug/with_state.hpp>

--- a/zug/transducer/distinct.hpp
+++ b/zug/transducer/distinct.hpp
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <zug/compose.hpp>
-#include <zug/detail/copy_traits.hpp>
 #include <zug/detail/tuple_utils.hpp>
 #include <zug/state_wrapper.hpp>
 #include <zug/util.hpp>

--- a/zug/transducer/interpose.hpp
+++ b/zug/transducer/interpose.hpp
@@ -10,7 +10,6 @@
 
 #include <zug/compat/apply.hpp>
 #include <zug/compose.hpp>
-#include <zug/detail/copy_traits.hpp>
 #include <zug/detail/empty_transducer_error.hpp>
 #include <zug/state_wrapper.hpp>
 #include <zug/util.hpp>

--- a/zug/transducer/write.hpp
+++ b/zug/transducer/write.hpp
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <zug/compose.hpp>
-#include <zug/detail/copy_traits.hpp>
 #include <zug/state_wrapper.hpp>
 #include <zug/util.hpp>
 #include <zug/with_state.hpp>


### PR DESCRIPTION
This change significantly reduces amount of struct templates one needs to instantiate to use `copy_decay` by merging `std::{is,add}_{const,volatile,lvalue_reference,rvalue_reference}` into 2 traits, specialized by hand; such a specialization (no sfinae used) should be relatively cheap to compile. It also removes a macro, used for codegen.

Lots of files, which included `copy_traits.hpp`, didn't use it at all, that's also fixed.