### PR TITLE
Fix `meta::bottom` conversion operator link errors (alternative)

### DIFF
--- a/zug/detail/unreachable.hpp
+++ b/zug/detail/unreachable.hpp
@@ -1,0 +1,18 @@
+//
+// zug: transducers for C++
+// Copyright (C) 2020 Juan Pedro Bolivar Puente
+//
+// This software is distributed under the Boost Software License, Version 1.0.
+// See accompanying file LICENSE or copy at http://boost.org/LICENSE_1_0.txt
+//
+
+#pragma once
+
+#if defined(_MSC_VER)
+#define ZUG_UNREACHABLE() __assume(0)
+#elif defined(__GNUC__)
+#define ZUG_UNREACHABLE() __builtin_unreachable()
+#else
+#error "__builtin_unreachable or equivalent support required"
+#define ZUG_UNREACHABLE()
+#endif

--- a/zug/meta/util.hpp
+++ b/zug/meta/util.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <zug/detail/unreachable.hpp>
+
 #include <type_traits>
 
 namespace zug {
@@ -43,16 +45,27 @@ struct identity
  * can be used as a placeholder for any parameter type in `result_of`
  * metacalls.
  *
- * @note Conversion is not defined. Only use in non-evaluated contexes.
+ * @note Only use in non-evaluated contexes, otherwise behavior is undefined.
  */
 struct bottom
 {
     template <typename T>
-    operator T &&() const;
+    operator T&&() const
+    {
+        ZUG_UNREACHABLE();
+    }
+
     template <typename T>
-    operator T&() const;
+    operator T&() const
+    {
+        ZUG_UNREACHABLE();
+    }
+    
     template <typename T>
-    operator const T&() const;
+    operator const T&() const
+    {
+        ZUG_UNREACHABLE();
+    }
 };
 
 /*!


### PR DESCRIPTION
Closes GH-9.
Competes with #13.

Solution @arximboldi suggested fixed link error for me. This should not break msvc, although I hadn't checked.