### PR TITLE
Make iter() constexpr

### DIFF
--- a/zug/transducer/iter.hpp
+++ b/zug/transducer/iter.hpp
@@ -53,7 +53,7 @@ bool state_wrapper_data_is_reduced(iter_tag, T&& iters)
     return get<0>(iters) == get<1>(iters);
 }
 
-auto iter() { return identity_; }
+constexpr auto iter() { return identity_; }
 
 /*!
  * Generator transducer produces the sequence passed as parameter, by


### PR DESCRIPTION
Otherwise we come into "multiple definitions of iter()."