### PR TITLE
Include tuplify in eager

### DIFF
--- a/zug/transducer/eager.hpp
+++ b/zug/transducer/eager.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <zug/tuplify.hpp>
 #include <zug/compose.hpp>
 #include <zug/detail/iterator_range.hpp>
 #include <zug/reduce_nested.hpp>


### PR DESCRIPTION
Testing source:
```

#include <zug/transducer/eager.hpp>
#include <zug/into_vector.hpp>
#include <vector>
#include <iostream>
#include <iterator>

int main()
{
    std::vector<int> a{1, 2};
    auto r = zug::into_vector(zug::reversed, a);
    for (auto i : r) {
        std::cout << i << std::endl;
    }
}
```

Before, this code emits a compilation error:
```
] g++ eager-tuplify.cpp -I<omitted>/external/zug -Wall -g
In file included from eager-tuplify.cpp:2:
<omitted>/external/zug/zug/transducer/eager.hpp: In instantiation of ‘zug::eager(Algo) [with Algo = zug::<lambda(auto:11&&)>]::<lambda(auto:7&&)> [with auto:7 = const zug::last_t&]::<lambda(auto:8&&, auto:9&& ...)> mutable [with auto:8 = zug::meta::bottom; auto:9 = {int}]’:
<omitted>/external/zug/zug/meta.hpp:65:14:   required from ‘struct zug::result_of<zug::composed<zug::eager(Algo) [with Algo = zug::<lambda(auto:11&&)>]::<lambda(auto:7&&)> >&, int>’
<omitted>/external/zug/zug/into_vector.hpp:26:6:   required by substitution of ‘template<class XformT, class ... InputRangeTs> std::vector<typename zug::result_of<XformT, typename std::decay<InputRangeTs>::type::value_type ...>::type> zug::into_vector(XformT&&, InputRangeTs&& ...) [with XformT = zug::composed<zug::eager(Algo) [with Algo = zug::<lambda(auto:11&&)>]::<lambda(auto:7&&)> >&; InputRangeTs = {std::vector<int, std::allocator<int> >&}]’
eager-tuplify.cpp:11:47:   required from here
<omitted>/external/zug/zug/transducer/eager.hpp:38:58: error: ‘tuplify’ was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation
   38 |                 std::vector<std::decay_t<decltype(tuplify(is...))>>;
      |                                                   ~~~~~~~^~~~~~~
<omitted>/external/zug/zug/transducer/eager.hpp:39:18: error: ‘void data’ has incomplete type
   39 |             auto data = state_data(ZUG_FWD(s), [&] {
      |                  ^~~~
<omitted>/external/zug/zug/transducer/eager.hpp:42:48: error: ‘tuplify’ was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation
   42 |             std::get<0>(data).push_back(tuplify(ZUG_FWD(is)...));
      |                                         ~~~~~~~^~~~~~~~~~~~~~~~
In file included from <omitted>/external/zug/zug/into_vector.hpp:11,
                 from eager-tuplify.cpp:3:
<omitted>/external/zug/zug/meta.hpp: In instantiation of ‘struct zug::result_of<zug::composed<zug::eager(Algo) [with Algo = zug::<lambda(auto:11&&)>]::<lambda(auto:7&&)> >&, int>’:
<omitted>/external/zug/zug/into_vector.hpp:26:6:   required by substitution of ‘template<class XformT, class ... InputRangeTs> std::vector<typename zug::result_of<XformT, typename std::decay<InputRangeTs>::type::value_type ...>::type> zug::into_vector(XformT&&, InputRangeTs&& ...) [with XformT = zug::composed<zug::eager(Algo) [with Algo = zug::<lambda(auto:11&&)>]::<lambda(auto:7&&)> >&; InputRangeTs = {std::vector<int, std::allocator<int> >&}]’
eager-tuplify.cpp:11:47:   required from here
<omitted>/external/zug/zug/meta.hpp:64:54: error: invalid use of void expression
   64 |     using type = std::decay_t<decltype(state_complete(std::declval<XformT>()(
      |                                        ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
   65 |         last)(std::declval<meta::bottom>(), std::declval<InputTs>()...)))>;
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
eager-tuplify.cpp: In function ‘int main()’:
eager-tuplify.cpp:11:47: error: no matching function for call to ‘into_vector(zug::composed<zug::eager(Algo) [with Algo = zug::<lambda(auto:11&&)>]::<lambda(auto:7&&)> >&, std::vector<int>&)’
   11 |     auto r = zug::into_vector(zug::reversed, a);
      |                                               ^
In file included from eager-tuplify.cpp:3:
<omitted>/external/zug/zug/into_vector.hpp:26:6: note: candidate: ‘template<class XformT, class ... InputRangeTs> std::vector<typename zug::result_of<XformT, typename std::decay<InputRangeTs>::type::value_type ...>::type> zug::into_vector(XformT&&, InputRangeTs&& ...)’
   26 | auto into_vector(XformT&& xform, InputRangeTs&&... ranges) -> std::vector<
      |      ^~~~~~~~~~~
<omitted>/external/zug/zug/into_vector.hpp:26:6: note:   substitution of deduced template arguments resulted in errors seen above
```

This PR fixed this problem.