### PR TITLE
Make reduce.cpp conform to c++14

### DIFF
--- a/test/reduce.cpp
+++ b/test/reduce.cpp
@@ -36,7 +36,9 @@ struct non_default
 struct foo_tag
 {};
 
-constexpr auto foo = [](auto step) {
+template<typename T>
+constexpr auto foo(T step)
+{
     return [=](auto&& s, auto&&... is) {
         return zug::wrap_state<foo_tag>(
             step(zug::state_unwrap(ZUG_FWD(s)), ZUG_FWD(is)...),


### PR DESCRIPTION
test/reduce.cpp failed to compile under g++ 9.3.
```
<omitted>/external/zug/test/reduce.cpp:39:16: error: the type ‘cost {anonymous}::<lambda(auto:1)>’ of ‘constexpr’ variable ‘{anonymous}::foo’ is not literal
   39 | constexpr auto foo = [](auto step) {
      |                ^~~
<omitted>/external/zug/test/reduce.cpp:39:23: note: ‘{anonymous}::<lambda(auto:1)>’ is not literal because:
   39 | constexpr auto foo = [](auto step) {
      |                       ^
cc1plus: note:   ‘{anonymous}::<lambda(auto:1)>’ is a closure type, which is only literal in C++17 and later
```

```
] gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/libexec/gcc/x86_64-pc-linux-gnu/9.3.0/lto-wrapper
Target: x86_64-pc-linux-gnu
Configured with: /var/tmp/portage/sys-devel/gcc-9.3.0-r1/work/gcc-9.3.0/configure --host=x86_64-pc-linux-gnu --build=x86_64-pc-linux-gnu --prefix=/usr --bindir=/usr/x86_64-pc-linux-gnu/gcc-bin/9.3.0 --includedir=/usr/lib/gcc/x86_64-pc-linux-gnu/9.3.0/include --datadir=/usr/share/gcc-data/x86_64-pc-linux-gnu/9.3.0 --mandir=/usr/share/gcc-data/x86_64-pc-linux-gnu/9.3.0/man --infodir=/usr/share/gcc-data/x86_64-pc-linux-gnu/9.3.0/info --with-gxx-include-dir=/usr/lib/gcc/x86_64-pc-linux-gnu/9.3.0/include/g++-v9 --with-python-dir=/share/gcc-data/x86_64-pc-linux-gnu/9.3.0/python --enable-languages=c,c++,fortran --enable-obsolete --enable-secureplt --disable-werror --with-system-zlib --enable-nls --without-included-gettext --enable-checking=release --with-bugurl=https://bugs.gentoo.org/ --with-pkgversion='Gentoo 9.3.0-r1 p3' --disable-esp --enable-libstdcxx-time --enable-shared --enable-threads=posix --enable-__cxa_atexit --enable-clocale=gnu --enable-multilib --with-multilib-list=m32,m64 --disable-fixed-point --enable-targets=all --enable-libgomp --disable-libssp --disable-libada --disable-systemtap --enable-vtable-verify --enable-lto --without-isl --enable-default-pie --enable-default-ssp
Thread model: posix
gcc version 9.3.0 (Gentoo 9.3.0-r1 p3) 
```