### PR TITLE
Fix compilation for MSVC and C++20

### DIFF
--- a/zug/skip.hpp
+++ b/zug/skip.hpp
@@ -121,8 +121,11 @@ template <typename ReducingFnT, typename StateT, typename... InputTs>
 struct skip_result_impl
 {
     using skipped_t = StateT;
+#ifdef __cpp_lib_is_invocable
+    using called_t  = std::invoke_result_t<ReducingFnT, StateT, InputTs...>;
+#else
     using called_t  = std::result_of_t<ReducingFnT(StateT, InputTs...)>;
-
+#endif
     using common_type_t = meta::common_type_t<skipped_t, called_t>;
     using error_t       = meta::could_not_find_common_type<skipped_t, called_t>;
 

--- a/zug/skip.hpp
+++ b/zug/skip.hpp
@@ -204,7 +204,7 @@ auto skip(StateT&& state) -> StateT&&
  */
 template <typename ReducingFnT, typename StateT, typename... InputTs>
 auto call(ReducingFnT&& step, StateT&& state, InputTs&&... ins)
-    -> std::enable_if_t<is_skip_state<std::decay_t<StateT>>{},
+    -> std::enable_if_t<is_skip_state<std::decay_t<StateT>>::value,
                         std::decay_t<StateT>>
 {
     return ZUG_VISIT(
@@ -217,7 +217,7 @@ auto call(ReducingFnT&& step, StateT&& state, InputTs&&... ins)
 
 template <typename ReducingFnT, typename StateT, typename... InputTs>
 auto call(ReducingFnT&& step, StateT&& state, InputTs&&... ins)
-    -> std::enable_if_t<!is_skip_state<std::decay_t<StateT>>{},
+    -> std::enable_if_t<!is_skip_state<std::decay_t<StateT>>::value,
                         skip_result_t<ReducingFnT, StateT, InputTs...>>
 {
     return std::forward<ReducingFnT>(step)(std::forward<StateT>(state),


### PR DESCRIPTION
Should fix issues #17 and #18.

For the MSVC fix, I don't understand why `is_skip_state<...>{}` doesn't compile, but replacing it by `is_skip_state<...>::value` seems to work... Maybe a MSVC bug?