### PR TITLE
cmake: add option to disable -Werror

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 project(zug VERSION 0.1.0)
 
 set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 set(CMAKE_EXPORT_COMPILE_COMMANDS on)
 set(CMAKE_CXX_EXTENSIONS off)
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
@@ -15,9 +15,15 @@ endif()
 
 include(GNUInstallDirs)
 
+option(DISABLE_WERROR "enable --werror")
+
 option(zug_BUILD_TESTS "Build tests" ON)
 option(zug_BUILD_EXAMPLES "Build examples" ON)
 option(zug_BUILD_DOCS "Build docs" ON)
+
+if (NOT MSVC AND NOT DISABLE_WERROR)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+endif()
 
 #  Targets
 #  =======


### PR DESCRIPTION
`-Werror` turns every compilation warning into an hard error; while it is convenient for development, it can be a problem in case of newer versions of compilers, as even potentially harmless warnings (e.g. deprecations) cause the build to fail.

Hence, add a CMake `DISABLE_WERROR` option to not add `-Werror` to the build flags.